### PR TITLE
Added PF2e specific hook

### DIFF
--- a/scripts/combat-ini-modifier.js
+++ b/scripts/combat-ini-modifier.js
@@ -90,7 +90,8 @@ class ExtendedCombatTracker {
     }
 
     registerHooks = () => {
-        Hooks.on('getCombatTrackerEntryContext', this.enhanceContextOptions)
+        Hooks.on('getCombatTrackerEntryContext', this.enhanceContextOptions);
+        Hooks.on('getPF2eCombatTrackerEntryContext', this.enhanceContextOptions);
     }
 }
 


### PR DESCRIPTION
the PF2e system replaces the getCombatTrackerEntryContext with its own hook. Feels like it should also honor the original hook, but in the meantime, added a line to register a 2nd hook.